### PR TITLE
fix error in TeamStream with replaced team name

### DIFF
--- a/src/Stream/SystemTeamStream.js
+++ b/src/Stream/SystemTeamStream.js
@@ -37,7 +37,7 @@ export default class SystemTeamStream extends Stream {
     const response = await client.requestImmediate('/user/teams');
     return response.body.map((item)=> {
       const org = item.organization.login;
-      const name = item.name.replace(/[/ ]/g, '-'); // if name includes '/', must replace to '-' in github
+      const name = item.name.replace(/\//g, '-'); // if name includes '/', must replace to '-' in github
       return `${org}/${name}`;
     });
   }


### PR DESCRIPTION
One of the teams I belong, it contains namespace in team name `Ubiregi Dev Team (Push & Pull)`.
And it causes an error as follow.

```
[E] [2018-10-05T23:32:32.203Z] [Stream.js:94:16] Error: {"message":"Validation Failed","errors":[{"message":"\"ubiregiinc/Ubiregi-Dev-Team-(Push-&-Pull)\" is not a valid team name.","resource":"Search","field":"q","code":"invalid"}],"documentation_url":"https://developer.github.com/v3/search/"}
    at IncomingMessage.res.on (/Users/watson/prj/jasper/src/GitHub/GitHubClient.js:96:16)
    at emitNone (events.js:111:20)
    at IncomingMessage.emit (events.js:208:7)
    at endReadableNT (_stream_readable.js:1056:12)
    at _combinedTickCallback (internal/process/next_tick.js:138:11)
    at process._tickCallback (internal/process/next_tick.js:180:9)
[E] [2018-10-05T23:32:32.203Z] [Stream.js:95:16] Error: {"message":"Validation Failed","errors":[{"message":"\"ubiregiinc/Ubiregi-Dev-Team-(Push-&-Pull)\" is not a valid team name.","resource":"Search","field":"q","code":"invalid"}],"documentation_url":"https://developer.github.com/v3/search/"}
```

Looks like that Jasper cannot search replaced team name `Ubiregi-Dev-Team-(Push-&-Pull)`.
I think that it should not replace the spaces in team name.

This patch will fix this error.