### PR TITLE
Fix generate token steps

### DIFF
--- a/src/Electron/html/setup/setup.html
+++ b/src/Electron/html/setup/setup.html
@@ -105,7 +105,7 @@
             <p>
               Jasper requires <code>repo</code> and <code>user</code> scopes.
               <br/>
-              <span style="font-size: 0.8em;">GitHub → Settings → Personal access tokens → Generate new token</span>
+              <span style="font-size: 0.8em;">GitHub → Settings → Developer settings → Personal access tokens → Generate new token</span>
             </p>
             <p><img src="./generate-token.png"></p>
           </div>


### PR DESCRIPTION
The URL for generating token still valid but GitHub moved
"Personal access tokens" under "Developer settings" menu.