### PR TITLE
Fix typo class name in SystemWatchingStream.js

### DIFF
--- a/src/Stream/SystemWatchingStream.js
+++ b/src/Stream/SystemWatchingStream.js
@@ -4,7 +4,7 @@ import Config from '../Config';
 import GitHubClient from '../GitHub/GitHubClient';
 import Stream from './Stream';
 
-export default class SystemTeamStream extends Stream {
+export default class SystemWatchingStream extends Stream {
   constructor(id, name, searchedAt) {
     super(id, name, [], searchedAt);
   }


### PR DESCRIPTION
:x: SystemTeamStream
:o: SystemWatchingStream

This change does not break anything because the changed name is not exported to the outside of the file.