### PR TITLE
Add link to DEVELOP.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,6 @@ You will be able to read, track and discover many active issues very flexibly by
 
 example `org:electron is:issue label:bug`
 
+## For Developers
+
+[DEVELOP.md](https://github.com/jasperapp/jasper/blob/master/DEVELOP.md)


### PR DESCRIPTION
Add link to DEVELOP.md

## Issues

Close https://github.com/jasperapp/jasper/issues/81

> By the way, I think adding a link to the document into the README.md is good idea.