### PR TITLE
Support macOS Mojave Dark Mode

### DIFF
--- a/script/mac/build.sh
+++ b/script/mac/build.sh
@@ -17,6 +17,7 @@ VERSION=$(grep version package.json | head -n 1 | cut -f 2 -d : | \sed 's/[",]//
 ./node_modules/.bin/electron-packager ./out/js Jasper \
   --asar=true \
   --overwrite \
+  --darwinDarkModeSupport=true \
   --icon=./misc/logo/jasper.icns \
   --platform=darwin \
   --arch=x64 \


### PR DESCRIPTION
This patch will generate the application which supports macOS Mojave Dark Mode.

![dark 2019-03-04 02_13_47](https://user-images.githubusercontent.com/199156/53698677-6c1b0b80-3e23-11e9-8614-aabb62b43347.gif)

(See https://electronjs.org/docs/tutorial/mojave-dark-mode-guide )