### PR TITLE
Fix broken layout in discussion timeline by removing css for old github

### DIFF
--- a/src/Electron/Component/WebViewComponentInjection/style.css
+++ b/src/Electron/Component/WebViewComponentInjection/style.css
@@ -1,15 +1,4 @@
 @media (min-width: 1020px) {
-  .main .container, /* for old github */
-  [role="main"] .container {
-    width: calc(100vw - 80px);
-    max-width: 1400px;
-  }
-
-  .container .discussion-timeline {
-    width: calc(100vw - 300px);
-    max-width: 1160px;
-  }
-
   .container .comment-holder {
     max-width: initial;
   }
@@ -18,7 +7,6 @@
     max-width: initial;
   }
 
-  body.full-width .main .container, /* for old github */
   body.full-width [role="main"] .container,
   body.full-width .container .discussion-timeline {
     max-width: none;


### PR DESCRIPTION
Recently, the layout in discussion timeline has broken if jasper app window was expanded as following.

Before | After
-- | --
<img width="1769" src="https://user-images.githubusercontent.com/199156/54077018-0bde0b00-42f6-11e9-866f-e335d9102d84.png"> | <img width="1871" src="https://user-images.githubusercontent.com/199156/54077027-34660500-42f6-11e9-9189-e015c9524724.png">


Seems this problem will be fixed if remove workaround for old github in `style.css`