### PR TITLE
Upgrade Electron to v5.0.0

### DIFF
--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -47,7 +47,7 @@ sqlite3 ./db
 - http://stackoverflow.com/questions/11856766/osx-notification-center-icon
 
 # Update Electron
-- `electron-prebuilt` in package.json
+- `electron` version in package.json
 - change electron version in ./script/{mac,win,linux}/build-sqlite3.sh
 - change sqlite3 version in ./script/{mac,win,linux}/build.sh
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@types/node": {
-      "version": "11.13.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.7.tgz",
-      "integrity": "sha512-suFHr6hcA9mp8vFrZTgrmqW2ZU3mbWsryQtQlY/QvwTISCw7nw/j+bCQPPohqmskhmqa5wLNuMHTTsc+xf1MQg==",
+      "version": "10.14.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.5.tgz",
+      "integrity": "sha512-Ja7d4s0qyGFxjGeDq5S7Si25OFibSAHUi6i17UWnwNnpitADN7hah9q0Tl25gxuV5R1u2Bx+np6w4LHXfHyj/g==",
       "dev": true
     },
     "abab": {
@@ -1326,22 +1326,14 @@
       }
     },
     "electron": {
-      "version": "5.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-5.0.0-beta.9.tgz",
-      "integrity": "sha512-9NV36qvnkJs9N2vS0lwq6jvFfHs3LSUyLKKIXltFpwgDt7VOcDZh4BPvO8A7S/XemTCsyCTsHGEiDSfSWLfUHg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-5.0.0.tgz",
+      "integrity": "sha512-++emIe4vLihiYiAVL+E8DT5vSNVFEIuQCRxA+VfpDRVBcog85UB28vi4ogRmMOK3UffzKdWV6e1jqp3T0KpBoA==",
       "dev": true,
       "requires": {
         "@types/node": "^10.12.18",
         "electron-download": "^4.1.0",
         "extract-zip": "^1.0.3"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "10.14.5",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.5.tgz",
-          "integrity": "sha512-Ja7d4s0qyGFxjGeDq5S7Si25OFibSAHUi6i17UWnwNnpitADN7hah9q0Tl25gxuV5R1u2Bx+np6w4LHXfHyj/g==",
-          "dev": true
-        }
       }
     },
     "electron-download": {
@@ -4539,8 +4531,8 @@
       "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-4.0.4.tgz",
       "integrity": "sha512-CO8vZMyUXBPC+E3iXOCc7Tz2pAdq5BWfLcQmOokCOZW5S5sZ/paijiPOCdvzpdP83RroWHYa5xYlVqCxSqpnQg==",
       "requires": {
-        "nan": "^2.10.0",
-        "node-pre-gyp": "^0.10.1",
+        "nan": "~2.10.0",
+        "node-pre-gyp": "^0.10.3",
         "request": "^2.87.0"
       },
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "jasper",
-  "version": "0.7.0",
+  "version": "0.7.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@types/node": {
-      "version": "8.10.30",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.30.tgz",
-      "integrity": "sha512-Le8HGMI5gjFSBqcCuKP/wfHC19oURzkU2D+ERIescUoJd+CmNEMYBib9LQ4zj1HHEZOJQWhw2ZTnbD8weASh/Q==",
+      "version": "11.13.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.7.tgz",
+      "integrity": "sha512-suFHr6hcA9mp8vFrZTgrmqW2ZU3mbWsryQtQlY/QvwTISCw7nw/j+bCQPPohqmskhmqa5wLNuMHTTsc+xf1MQg==",
       "dev": true
     },
     "abab": {
@@ -24,14 +24,14 @@
     },
     "acorn": {
       "version": "2.7.0",
-      "resolved": "http://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
       "integrity": "sha1-q259nYhqrKiwhbwzEreaGYQz8Oc=",
       "dev": true,
       "optional": true
     },
     "acorn-globals": {
       "version": "1.0.9",
-      "resolved": "http://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
       "integrity": "sha1-VbtemGkVB7dFedBRNBMhfDgMVM8=",
       "dev": true,
       "optional": true,
@@ -1143,15 +1143,15 @@
       }
     },
     "css-what": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
-      "integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0=",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
+      "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==",
       "dev": true
     },
     "cssom": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.4.tgz",
-      "integrity": "sha512-+7prCSORpXNeR4/fUP3rL+TzqtiFfhMvTd7uEqMdgPvLPt4+uzFUeufx5RHjGTACCargg/DiEt/moMQmvnfkog==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.6.tgz",
+      "integrity": "sha512-DtUeseGk9/GBW0hl0vVPpU22iHL6YB5BUX7ml1hB+GMpo0NX5G4voX3kdWiMSEguFtcW3Vh3djqNF4aIe6ne0A==",
       "dev": true,
       "optional": true
     },
@@ -1281,27 +1281,19 @@
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
     },
     "dom-serializer": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-      "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
+      "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
       "dev": true,
       "requires": {
-        "domelementtype": "~1.1.1",
-        "entities": "~1.1.1"
-      },
-      "dependencies": {
-        "domelementtype": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
-          "dev": true
-        }
+        "domelementtype": "^1.3.0",
+        "entities": "^1.1.1"
       }
     },
     "domelementtype": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
       "dev": true
     },
     "domhandler": {
@@ -1334,9 +1326,9 @@
       }
     },
     "electron": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-4.0.4.tgz",
-      "integrity": "sha512-zG5VtLrmPfmw1fXY/3BEtRZk7OZ7djQhweZ6rW+R5NeF6s8RTz/AwTGtLoBo4z8wmJ5QTy0Y941FZw4pe5YlpA==",
+      "version": "5.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-5.0.0-beta.9.tgz",
+      "integrity": "sha512-9NV36qvnkJs9N2vS0lwq6jvFfHs3LSUyLKKIXltFpwgDt7VOcDZh4BPvO8A7S/XemTCsyCTsHGEiDSfSWLfUHg==",
       "dev": true,
       "requires": {
         "@types/node": "^10.12.18",
@@ -1345,9 +1337,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.12.25",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.25.tgz",
-          "integrity": "sha512-IcvnGLGSQFDvC07Bz2I8SX+QKErDZbUdiQq7S2u3XyzTyJfUmT0sWJMbeQkMzpTAkO7/N7sZpW/arUM2jfKsbQ==",
+          "version": "10.14.5",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.5.tgz",
+          "integrity": "sha512-Ja7d4s0qyGFxjGeDq5S7Si25OFibSAHUi6i17UWnwNnpitADN7hah9q0Tl25gxuV5R1u2Bx+np6w4LHXfHyj/g==",
           "dev": true
         }
       }
@@ -1521,9 +1513,9 @@
       }
     },
     "entities": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
-      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
       "dev": true
     },
     "env-paths": {
@@ -1553,9 +1545,9 @@
       "dev": true
     },
     "escodegen": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.0.tgz",
-      "integrity": "sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.1.tgz",
+      "integrity": "sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -2127,7 +2119,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2148,12 +2141,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2168,17 +2163,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2295,7 +2293,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2307,6 +2306,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2321,6 +2321,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2328,12 +2329,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2352,6 +2355,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2432,7 +2436,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2444,6 +2449,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2529,7 +2535,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2565,6 +2572,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2584,6 +2592,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2627,12 +2636,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -2800,6 +2811,7 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-glob": "^2.0.0"
       }
@@ -2860,17 +2872,39 @@
       "dev": true
     },
     "htmlparser2": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
-      "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+      "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
       "dev": true,
       "requires": {
-        "domelementtype": "^1.3.0",
+        "domelementtype": "^1.3.1",
         "domhandler": "^2.3.0",
         "domutils": "^1.5.1",
         "entities": "^1.1.1",
         "inherits": "^2.0.1",
-        "readable-stream": "^2.0.2"
+        "readable-stream": "^3.1.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
+          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
+          "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "http-signature": {
@@ -2951,7 +2985,7 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
@@ -3071,7 +3105,8 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-dotfile": {
       "version": "1.0.3",
@@ -3101,7 +3136,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
       "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-finite": {
       "version": "1.0.2",
@@ -3125,6 +3161,7 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-extglob": "^1.0.0"
       }
@@ -3220,7 +3257,7 @@
     },
     "jsdom": {
       "version": "7.2.2",
-      "resolved": "http://registry.npmjs.org/jsdom/-/jsdom-7.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-7.2.2.tgz",
       "integrity": "sha1-QLQCdwwr2iNGkJa+6Rq2deOx/G4=",
       "dev": true,
       "optional": true,
@@ -3311,6 +3348,7 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-buffer": "^1.1.5"
       }
@@ -3712,6 +3750,7 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
+      "optional": true,
       "requires": {
         "remove-trailing-separator": "^1.0.1"
       }
@@ -3742,9 +3781,9 @@
       }
     },
     "nth-check": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
-      "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
+      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
       "dev": true,
       "requires": {
         "boolbase": "~1.0.0"
@@ -4001,7 +4040,8 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "preserve": {
       "version": "0.2.0",
@@ -4252,13 +4292,15 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "repeat-element": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
       "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "repeat-string": {
       "version": "1.6.1",
@@ -4497,8 +4539,8 @@
       "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-4.0.4.tgz",
       "integrity": "sha512-CO8vZMyUXBPC+E3iXOCc7Tz2pAdq5BWfLcQmOokCOZW5S5sZ/paijiPOCdvzpdP83RroWHYa5xYlVqCxSqpnQg==",
       "requires": {
-        "nan": "~2.10.0",
-        "node-pre-gyp": "^0.10.3",
+        "nan": "^2.10.0",
+        "node-pre-gyp": "^0.10.1",
         "request": "^2.87.0"
       },
       "dependencies": {
@@ -4692,14 +4734,23 @@
       }
     },
     "tough-cookie": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
       "dev": true,
       "optional": true,
       "requires": {
-        "psl": "^1.1.24",
-        "punycode": "^1.4.1"
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "tr46": {
@@ -4755,6 +4806,7 @@
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
+      "optional": true,
       "requires": {
         "prelude-ls": "~1.1.2"
       }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
     "babel-preset-react": "6.24.1",
     "babel-register": "6.26.0",
-    "electron": "4.0.4",
+    "electron": "5.0.0-beta.9",
     "electron-packager": "13.0.1",
     "esdoc": "latest",
     "esdoc-jsx-plugin": "latest",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
     "babel-preset-react": "6.24.1",
     "babel-register": "6.26.0",
-    "electron": "5.0.0-beta.9",
+    "electron": "5.0.0",
     "electron-packager": "13.0.1",
     "esdoc": "latest",
     "esdoc-jsx-plugin": "latest",

--- a/script/linux/build-sqlite3.sh
+++ b/script/linux/build-sqlite3.sh
@@ -3,5 +3,5 @@ cd ./node_modules/sqlite3
 npm i nan@2.10.0
 npm i node-pre-gyp@0.10.1
 npm i -g node-gyp@3.8.0
-node-gyp configure --module_name=node_sqlite3 --module_path=../lib/binding/electron-v4.0-linux-x64
-node-gyp rebuild --target=4.0.4 --arch=x64 --target_platform=linux --dist-url=https://atom.io/download/electron --module_name=node_sqlite3 --module_path=../lib/binding/electron-v4.0-linux-x64
+node-gyp configure --module_name=node_sqlite3 --module_path=../lib/binding/electron-v5.0-linux-x64
+node-gyp rebuild --target=5.0.0-beta.9 --arch=x64 --target_platform=linux --dist-url=https://atom.io/download/electron --module_name=node_sqlite3 --module_path=../lib/binding/electron-v5.0-linux-x64

--- a/script/linux/build-sqlite3.sh
+++ b/script/linux/build-sqlite3.sh
@@ -4,4 +4,4 @@ npm i nan@2.10.0
 npm i node-pre-gyp@0.10.1
 npm i -g node-gyp@3.8.0
 node-gyp configure --module_name=node_sqlite3 --module_path=../lib/binding/electron-v5.0-linux-x64
-node-gyp rebuild --target=5.0.0-beta.9 --arch=x64 --target_platform=linux --dist-url=https://atom.io/download/electron --module_name=node_sqlite3 --module_path=../lib/binding/electron-v5.0-linux-x64
+node-gyp rebuild --target=5.0.0 --arch=x64 --target_platform=linux --dist-url=https://atom.io/download/electron --module_name=node_sqlite3 --module_path=../lib/binding/electron-v5.0-linux-x64

--- a/script/linux/build.sh
+++ b/script/linux/build.sh
@@ -7,7 +7,7 @@ rm -rf ./out/build
 ./script/build-js.sh
 
 # electron requires electron-vX.Y-linux-x64 of sqlite3
-cp -a ./node_modules/sqlite3/lib/binding/electron-v4.0-linux-x64 ./out/js/node_modules/sqlite3/lib/binding/
+cp -a ./node_modules/sqlite3/lib/binding/electron-v5.0-linux-x64 ./out/js/node_modules/sqlite3/lib/binding/
 
 # build app with electron-packager
 VERSION=$(grep version package.json | head -n 1 | cut -f 2 -d : | \sed 's/[",]//g')

--- a/script/mac/build-sqlite3.sh
+++ b/script/mac/build-sqlite3.sh
@@ -3,5 +3,5 @@ cd ./node_modules/sqlite3
 npm i nan@2.10.0
 npm i node-pre-gyp@0.10.1
 npm i -g node-gyp@3.8.0
-node-gyp configure  --module_name=node_sqlite3 --module_path=../lib/binding/electron-v4.0-darwin-x64
-node-gyp rebuild  --target=4.0.4 --arch=x64 --target_platform=darwin --dist-url=https://atom.io/download/electron --module_name=node_sqlite3 --module_path=../lib/binding/electron-v4.0-darwin-x64
+node-gyp configure  --module_name=node_sqlite3 --module_path=../lib/binding/electron-v5.0-darwin-x64
+node-gyp rebuild  --target=5.0.0-beta.9 --arch=x64 --target_platform=darwin --dist-url=https://atom.io/download/electron --module_name=node_sqlite3 --module_path=../lib/binding/electron-v5.0-darwin-x64

--- a/script/mac/build-sqlite3.sh
+++ b/script/mac/build-sqlite3.sh
@@ -4,4 +4,4 @@ npm i nan@2.10.0
 npm i node-pre-gyp@0.10.1
 npm i -g node-gyp@3.8.0
 node-gyp configure  --module_name=node_sqlite3 --module_path=../lib/binding/electron-v5.0-darwin-x64
-node-gyp rebuild  --target=5.0.0-beta.9 --arch=x64 --target_platform=darwin --dist-url=https://atom.io/download/electron --module_name=node_sqlite3 --module_path=../lib/binding/electron-v5.0-darwin-x64
+node-gyp rebuild  --target=5.0.0 --arch=x64 --target_platform=darwin --dist-url=https://atom.io/download/electron --module_name=node_sqlite3 --module_path=../lib/binding/electron-v5.0-darwin-x64

--- a/script/mac/build.sh
+++ b/script/mac/build.sh
@@ -10,7 +10,7 @@ iconutil -c icns ./misc/logo/jasper.iconset --output ./misc/logo/jasper.icns
 ./script/build-js.sh
 
 # electron requires electron-vX.Y-darwin-x64 of sqlite3
-cp -a ./node_modules/sqlite3/lib/binding/electron-v4.0-darwin-x64 ./out/js/node_modules/sqlite3/lib/binding/
+cp -a ./node_modules/sqlite3/lib/binding/electron-v5.0-darwin-x64 ./out/js/node_modules/sqlite3/lib/binding/
 
 # build app with electron-packager
 VERSION=$(grep version package.json | head -n 1 | cut -f 2 -d : | \sed 's/[",]//g')

--- a/script/win/build-sqlite.sh
+++ b/script/win/build-sqlite.sh
@@ -8,5 +8,5 @@ cd ./node_modules/sqlite3
 npm i nan@2.10.0
 npm i node-pre-gyp@0.10.1
 npm i -g node-gyp@3.8.0
-node-gyp configure  --module_name=node_sqlite3 --module_path=../lib/binding/electron-v4.0-win32-x64
-node-gyp rebuild  --msvs_version=2015 --target=4.0.4 --arch=x64 --target_platform=win32 --dist-url=https://atom.io/download/electron --module_name=node_sqlite3 --module_path=../lib/binding/electron-v4.0-win32-x64
+node-gyp configure  --module_name=node_sqlite3 --module_path=../lib/binding/electron-v5.0-win32-x64
+node-gyp rebuild  --msvs_version=2015 --target=5.0.0-beta.9 --arch=x64 --target_platform=win32 --dist-url=https://atom.io/download/electron --module_name=node_sqlite3 --module_path=../lib/binding/electron-v5.0-win32-x64

--- a/script/win/build-sqlite.sh
+++ b/script/win/build-sqlite.sh
@@ -9,4 +9,4 @@ npm i nan@2.10.0
 npm i node-pre-gyp@0.10.1
 npm i -g node-gyp@3.8.0
 node-gyp configure  --module_name=node_sqlite3 --module_path=../lib/binding/electron-v5.0-win32-x64
-node-gyp rebuild  --msvs_version=2015 --target=5.0.0-beta.9 --arch=x64 --target_platform=win32 --dist-url=https://atom.io/download/electron --module_name=node_sqlite3 --module_path=../lib/binding/electron-v5.0-win32-x64
+node-gyp rebuild  --msvs_version=2015 --target=5.0.0 --arch=x64 --target_platform=win32 --dist-url=https://atom.io/download/electron --module_name=node_sqlite3 --module_path=../lib/binding/electron-v5.0-win32-x64

--- a/script/win/build.sh
+++ b/script/win/build.sh
@@ -7,7 +7,7 @@ rm -rf ./out/build
 ./script/build-js.sh
 
 # electron requires electron-vX.Y-win32-x64 of sqlite3
-cp -a ./node_modules/sqlite3/lib/binding/electron-v4.0-win32-x64 ./out/js/node_modules/sqlite3/lib/binding/
+cp -a ./node_modules/sqlite3/lib/binding/electron-v5.0-win32-x64 ./out/js/node_modules/sqlite3/lib/binding/
 
 # build app with electron-packager
 VERSION=$(grep version package.json | head -n 1 | cut -f 2 -d : | \sed 's/[",]//g')

--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,7 @@ electron.app.on('will-finish-launching', () => {
 });
 
 electron.app.on('ready', function() {
-  const config = {width: 1280, height: 900, title: 'Jasper'};
+  const config = {width: 1280, height: 900, title: 'Jasper', webPreferences: {nodeIntegration: true}};
   if (Platform.isLinux()) config.icon = `${__dirname}/Electron/image/icon.png`;
   global.mainWindow = mainWindow = new electron.BrowserWindow(config);
 
@@ -478,7 +478,10 @@ function showPreferences() {
     maximizable: false,
     fullscreenable: false,
     resizable: false,
-    parent: mainWindow
+    parent: mainWindow,
+    webPreferences: {
+      nodeIntegration: true
+    }
   });
   prefWindow.loadURL(`file://${__dirname}/Electron/html/preferences/preferences.html`);
 
@@ -643,7 +646,10 @@ function showLogs() {
     minimizable: false,
     maximizable: false,
     fullscreenable: false,
-    parent: mainWindow
+    parent: mainWindow,
+    webPreferences: {
+      nodeIntegration: true
+    }
   });
   logsWindow.loadURL(`file://${__dirname}/Electron/html/logs/logs.html`);
   logsWindow.on('closed', ()=>{
@@ -667,7 +673,10 @@ function showAbout() {
     maximizable: false,
     fullscreenable: false,
     resizable: false,
-    parent: mainWindow
+    parent: mainWindow,
+    webPreferences: {
+      nodeIntegration: true
+    }
   });
 
   const version = electron.app.getVersion();


### PR DESCRIPTION
This upgrades Electron to the latest major version, and fixes the window creation code to explicitly enable the `nodeIntegration` that content pages currently rely on.

[In Electron 5](https://electronjs.org/releases/stable#release-notes-for-v500), without `nodeIntergration` explicitly enabled, the content pages do not have access to `require`!