### PR TITLE
Defer showing of dialogs until they're loaded

### DIFF
--- a/src/Electron/html/preferences/preferences.js
+++ b/src/Electron/html/preferences/preferences.js
@@ -31,6 +31,11 @@ function getConfig() {
 }
 
 {
+  // wait for web fonts
+  document.fonts.ready.then(()=>{
+    require('electron').ipcRenderer.send('fonts-ready');
+  });
+
   // load current config
   require('electron').ipcRenderer.on('current-config', (event, config)=> {
     currentConfig = config;

--- a/src/index.js
+++ b/src/index.js
@@ -474,13 +474,18 @@ function showPreferences() {
     title: 'Preferences',
     width: 500,
     height: 350,
+    backgroundColor: "#e7e7e7",
     minimizable: false,
     maximizable: false,
     fullscreenable: false,
     resizable: false,
+    show: false,
     parent: mainWindow
   });
   prefWindow.loadURL(`file://${__dirname}/Electron/html/preferences/preferences.html`);
+  ipcMain.once('fonts-ready', ()=>{
+    prefWindow.show();
+  });
 
   prefWindow.webContents.on('dom-ready', ()=>{
     prefWindow.webContents.send('current-config', config);
@@ -643,6 +648,7 @@ function showLogs() {
     minimizable: false,
     maximizable: false,
     fullscreenable: false,
+    backgroundColor: "#e7e7e7",
     parent: mainWindow
   });
   logsWindow.loadURL(`file://${__dirname}/Electron/html/logs/logs.html`);
@@ -663,15 +669,20 @@ function showAbout() {
     title: '',
     width: 275,
     height: 265,
+    backgroundColor: "#e7e7e7",
     minimizable: false,
     maximizable: false,
     fullscreenable: false,
     resizable: false,
+    show: false,
     parent: mainWindow
   });
 
   const version = electron.app.getVersion();
   aboutWindow.loadURL(`file://${__dirname}/Electron/html/about.html#${version}`);
+  aboutWindow.once('ready-to-show', ()=>{
+    aboutWindow.show();
+  });
   aboutWindow.on('closed', ()=>{
     Menu.setApplicationMenu(appMenu);
   });


### PR DESCRIPTION
Currently, dialogs are shown immediately, which incurs a delay with a blank screen while their resources load.

This defers the showing of the About and Preferences dialogs until they're loaded.

In the case of the About dialog, we wait for the built-in `ready-to-show` event, as [recommended by the Electron documentation](https://electronjs.org/docs/api/browser-window#showing-window-gracefully).

The Preferences window, on the other hand, has some extra resources to gather, in this case the icon web font, so instead I've made it wait for the fonts to finish loading, by making use of the `document.fonts.ready` Promise!

Just to be thorough, I've made these two dialogs use the background colour they'll eventually have while loading, just in case they experience any other slow loads. Makes it a bit more seamless 😄