### PR TITLE
Detect input when Enter key is pressed

### DIFF
--- a/src/Electron/Component/AppComponent.js
+++ b/src/Electron/Component/AppComponent.js
@@ -318,6 +318,8 @@ export default class AppComponent extends React.Component {
       if (ev.keyCode === 27 && document.activeElement) {
         document.activeElement.blur();
         electron.ipcRenderer.send('keyboard-shortcut', true);
+      } else if (ev.keyCode === 13 && document.activeElement) {
+        detect(ev);
       }
     });
   }

--- a/src/Electron/Component/WebViewComponentInjection/detect-input.js
+++ b/src/Electron/Component/WebViewComponentInjection/detect-input.js
@@ -14,6 +14,11 @@
 
   window.addEventListener('click', detect, true);
   window.addEventListener('focus', detect, true);
+  window.addEventListener('keyup', (ev)=>{
+    if (ev.keyCode === 13 && document.activeElement) {
+      detect(ev);
+    }
+  });
 
   // <input autofocus="autofocus"> has already focus at dom-ready
   if (document.activeElement) detect({srcElement: document.activeElement});


### PR DESCRIPTION
## Issue

In browser view, when I am typing a comment and select emoji (`:+1:` etc) or mention a person (`@giga811` etc) the `DETECT_INPUT` is lost.
It is causing app's keyboard shortcut being activated while I am typing.

It is happening when I select the item by pressing `Enter`. It doesn't happen when I click the item.

## Fix

Run detect() function when the `Enter` key is pressed.
So that when I select emoji or person the detect function runs and correctly detecting the input.

| before | after |
| :------------: | :------------: |
| <img src="https://user-images.githubusercontent.com/4250931/57612090-1f844700-75af-11e9-86b0-e20b4b54627b.gif" /> | <img src="https://user-images.githubusercontent.com/4250931/57612069-18f5cf80-75af-11e9-95dc-e59894108eed.gif" /> |


