### PR TITLE
Fix an issue where themes could not be loaded

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -566,7 +566,7 @@ function showPreferences() {
     ipcMain.removeAllListeners('load-streams');
     ipcMain.on('load-streams', async () =>{
       const defaultPath = app.getPath('downloads') + '/jasper-streams.json';
-      const tmp = electron.dialog.showOpenDialog({defaultPath, properties: ['openFile']});
+      const tmp = electron.dialog.showOpenDialogSync({defaultPath, properties: ['openFile']});
       if (!tmp || !tmp.length) return;
 
       const filePath = tmp[0];
@@ -588,7 +588,7 @@ function showPreferences() {
         properties: ['openFile'],
         filters: [{name: 'CSS', extensions: ['css']}]
       };
-      const tmp = electron.dialog.showOpenDialog(option);
+      const tmp = electron.dialog.showOpenDialogSync(option);
       if (!tmp || !tmp.length) return;
 
       const filePath = tmp[0];
@@ -614,7 +614,7 @@ function showPreferences() {
         properties: ['openFile'],
         filters: [{name: 'CSS', extensions: ['css']}]
       };
-      const tmp = electron.dialog.showOpenDialog(option);
+      const tmp = electron.dialog.showOpenDialogSync(option);
       if (!tmp || !tmp.length) return;
 
       const filePath = tmp[0];


### PR DESCRIPTION
This PR will fix an issue where themes could not be loaded with 0.8.0-beta.1.

## Description

Seems that `dialog.showOpenDialog()` API will get a file path asynchronously.
https://electronjs.org/docs/api/dialog#dialogshowopendialogbrowserwindow-options

The API returns a Promise Object immediately and fails to get the file path.

So, this PR will use `dialog.showOpenDialogSync()` instead to fix the issue.

## Reproduce

1. Open `Preferences` in Menu bar.
2. Select `Theme` tab and load the theme file.