### PR TITLE
Load Browser Theme when launch BrowserViewComponent

### DIFF
--- a/src/Bootstrap.js
+++ b/src/Bootstrap.js
@@ -257,13 +257,6 @@ export class Bootstrap {
     } else {
       global.mainWindow.webContents.send('load-theme-main', '');
     }
-
-    if (Config.themeBrowserPath)  {
-      const css = fs.readFileSync(Config.themeBrowserPath).toString();
-      global.mainWindow.webContents.send('load-theme-browser', css);
-    } else {
-      global.mainWindow.webContents.send('load-theme-browser', '');
-    }
   }
 }
 

--- a/src/Electron/Component/BrowserViewComponent.js
+++ b/src/Electron/Component/BrowserViewComponent.js
@@ -146,6 +146,8 @@ export default class WebViewComponent extends React.Component {
       });
     }
 
+    this._loadTheme();
+
     this._setupDetectInput(webView);
     this._setupPageLoading(webView);
     this._setup404(webView);
@@ -184,6 +186,14 @@ export default class WebViewComponent extends React.Component {
       currentUrl: issue.value.html_url,
       classNameLoading: this.state.currentUrl === issue.value.html_url ? '' : 'loading'
     });
+  }
+
+  _loadTheme() {
+    if (Config.themeBrowserPath)  {
+      const css = fs.readFileSync(Config.themeBrowserPath).toString();
+      this._injectionCode.theme = css;
+      if (this._injectionCode.theme) this._webView.insertCSS(this._injectionCode.theme);
+    }
   }
 
   _isTargetIssuePage() {


### PR DESCRIPTION
fix https://github.com/jasperapp/jasper/issues/103

`Bootstrap` loads css before preparing BrowserViewComponent.
Then Browser Theme can't be applied.

So this PR will load the theme in BrowserViewComponent.