### PR TITLE
Enable Hardened Runtime Entitlements

### DIFF
--- a/misc/plist/notarization.plist
+++ b/misc/plist/notarization.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+  </dict>
+</plist>

--- a/script/mac/codesign-developer.sh
+++ b/script/mac/codesign-developer.sh
@@ -23,8 +23,9 @@ electron-osx-sign ./out/mac/Jasper.app \
 --platform=darwin \
 --identity="Developer ID Application: Ryo Maruyama (G3Z4F76FBZ)" \
 --type=distribution \
-# --entitlements="./misc/plist/parent.plist" \
-# --entitlements-inherit="./misc/plist/child.plist" \
+--hardened-runtime \
+--entitlements="./misc/plist/notarization.plist" \
+--entitlements-inherit="./misc/plist/notarization.plist" \
 # --ignore="Jasper Helper .*" \
 # --no-pre-auto-entitlements \
 # --no-gatekeeper-assess \


### PR DESCRIPTION
Apple’s notarizing system requires Hardened Runtime Entitlements.

Refer:
- https://developer.apple.com/documentation/security/hardened_runtime_entitlements
- https://github.com/electron/electron-osx-sign
- https://uechi.io/blog/sign-and-notarize-electron-app

Related to https://github.com/jasperapp/jasper/issues/99