### PR TITLE
Workaround for breaking layout with cached zoom factor

### DIFF
--- a/src/Electron/Component/AppComponent.js
+++ b/src/Electron/Component/AppComponent.js
@@ -36,6 +36,7 @@ export default class AppComponent extends React.Component {
     this._systemStreamListenerId = [];
     this._ga();
     electron.webFrame.setVisualZoomLevelLimits(1, 1);
+    electron.webFrame.setZoomFactor(1.0);
   }
 
   _ga() {


### PR DESCRIPTION
Seems Electron has been cached zoom factor automatically.
And it will break layout.

This patch will use `setZoomFactor()` as workaround to solve the issue.

Close #109