### PR TITLE
Run VACUUM command at quit

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@ let appMenu = null;
 let minimumMenu = null;
 electron.app.on('window-all-closed', async ()=>{
   await require('./Util/GA').default.eventAppEnd('app', 'end');
+  await require('./DB/DB').default.exec('vacuum');
   electron.app.quit();
 });
 
@@ -335,6 +336,7 @@ electron.app.on('ready', function() {
 
 async function quit() {
   await require('./Util/GA').default.eventAppEnd('app', 'end');
+  await require('./DB/DB').default.exec('vacuum');
   electron.app.exit(0);
 }
 


### PR DESCRIPTION
If I set the maximum number of records as lower value, Jasper will delete exceeding old data.
If run the `VACUUM` command, it will keep the DB file to small size.