### PR TITLE
Fix an issue where streams could not be saved

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -553,7 +553,7 @@ function showPreferences() {
     ipcMain.removeAllListeners('save-streams');
     ipcMain.on('save-streams', async () =>{
       const defaultPath = app.getPath('downloads') + '/jasper-streams.json';
-      const filePath = electron.dialog.showSaveDialog({defaultPath});
+      const filePath = electron.dialog.showSaveDialogSync({defaultPath});
       if (!filePath) return;
 
       const output = await require('./Stream/SaveAndLoadStreams').default.save();


### PR DESCRIPTION
Similar with #100.

## Description

Seems that `dialog.showSaveDialog()` API will get a file path asynchronously.
https://electronjs.org/docs/api/dialog#dialogshowsavedialogbrowserwindow-options

The API returns a Promise Object immediately and fails to get the file path.

So, this PR will use `dialog.showSaveDialogSync()` instead to fix the issue.

## Reproduce

1. Open `Preferences` in Menu bar.
2. Select `Streams` tab and save streams to file