### PR TITLE
use slug for team name

### DIFF
--- a/src/Stream/SystemTeamStream.ts
+++ b/src/Stream/SystemTeamStream.ts
@@ -37,7 +37,7 @@ export default class SystemTeamStream extends Stream {
     const response = await client.requestImmediate('/user/teams');
     return response.body.map((item)=> {
       const org = item.organization.login;
-      const name = item.name.replace(/[/ .]/g, '-'); // if name includes '/', must replace to '-' in github
+      const name = item.slug;
       return `${org}/${name}`;
     });
   }


### PR DESCRIPTION
It should use team.slug instead of team.name.

GitHub API uses the team's slug as parameter, which is generated by team's name.
ex. https://developer.github.com/v3/teams/#get-a-team-by-name

For instance, Jasper recognize team name as `"foo/bar@baz"` if team name is `"foo/bar@baz"`.
But github creates slug as `"bar-baz"`.