### PR TITLE
refactor: use electron session to retrieve cookie

### DIFF
--- a/src/Main/GitHub/GitHubClient.ts
+++ b/src/Main/GitHub/GitHubClient.ts
@@ -7,7 +7,6 @@ import os from 'os';
 import {GitHubClientDeliver} from './GitHubClientDeliver';
 import {Timer} from '../../Util/Timer';
 import {Identifier} from '../../Util/Identifier';
-import {AppWindow} from '../AppWindow';
 
 type Response = {
   body: any;
@@ -73,11 +72,10 @@ export class GitHubClient {
         }
       };
 
-      // todo: ここでmainWindowに触るのはさすがに微妙なのでなんとかする
-      const allCookies = await AppWindow.getWindow().webContents.session.cookies.get({
+      const allCookies = await electron.session.defaultSession?.cookies.get({
         domain: this._host,
         url: `https://${this._host}`,
-      });
+      }) ?? [];
       const secureCookies = allCookies.filter(cookie => cookie.secure && cookie.httpOnly)
       if (secureCookies.length) {
         options.headers['Cookie'] = secureCookies.map(cookie => `${cookie.name}=${cookie.value}`).join(';');


### PR DESCRIPTION
We can use `session.defaultSession` to access app shared cookies for Main process.
https://www.electronjs.org/docs/api/session#sessiondefaultsession