### PR TITLE
fix(v4): support optional rateLimit

### DIFF
--- a/src/Renderer/Library/Type/RemoteGitHubV4/RemoteGitHubV4Entity.ts
+++ b/src/Renderer/Library/Type/RemoteGitHubV4/RemoteGitHubV4Entity.ts
@@ -1,8 +1,10 @@
-export type RemoteGitHubV4Entity = {
-  rateLimit: {
+export type RemoteGitHubV4RateLimitEntity = {
     cost: number;
     limit: number;
     remaining: number;
     resetAt: string; // YYYY-MM-DDThh:mm:ssZ
-  }
+}
+
+export type RemoteGitHubV4Entity = {
+  rateLimit?: RemoteGitHubV4RateLimitEntity;
 }


### PR DESCRIPTION
This change will fix `TypeError: Cannot read property 'remaining' of null at GitHubV4IssueClient.waitRateLimit`.

`rateLimit` field is optional according to the API document.
https://developer.github.com/v4/query/#ratelimit
Specifically, It seems the graphql api on GHE without rate limiting configuration returns `rateLimit: null`.

In that case, we can just skip awaiting.

thanks,