### PR TITLE
Fix no config case when setting up as a new user

### DIFF
--- a/src/Main/Bind/UserPrefBind.ts
+++ b/src/Main/Bind/UserPrefBind.ts
@@ -18,7 +18,7 @@ class _UserPrefBind {
 
   private read(): string {
     const path = this.getPrefPath();
-    if (!fs.existsSync(path)) this.write('');
+    if (!fs.existsSync(path)) this.write('[]');
 
     return fs.readFileSync(path).toString();
   }


### PR DESCRIPTION
This is intended to fix this issue: ~https://github.com/jasperapp/jasper/issues/188~ https://github.com/jasperapp/jasper/issues/60

I can't actually see what causes that issue via devtools, but this change allows me to set up Jasper as a new user, regardless of whether I have an existing config or not.

Without this change, I was unable to get past step 3 of setup on MacOS with version v1.0.2 or v0.9.3. The app would write an empty config, read it again, and get stuck. After this change, I'm able to delete the config and database, run Jasper and finally complete the setup.