### PR TITLE
add requirement instruction to DEVELOP.md

### DIFF
--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -1,4 +1,9 @@
 # Development
+
+## Requirement
+
+Needs Node 10 or 12. `sqlite3@4.1.1` that Jasper depends on doesn't support Node 14.
+
 ## Run as Development
 
 ```


### PR DESCRIPTION
Node < 14 だと `sqlite3@4.1.1` が対応していなくて `npm i` がコケてしまった。
5.0.0 で Node 14 がサポートされているが、メジャーアップデートなのでいったん DEVELOP.md に記載して対応した。
https://github.com/mapbox/node-sqlite3/releases/tag/v5.0.0