### PR TITLE
fix(BrowserLoadFragment): unexpectation moving stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # next
 - **Fix**
-  - [#198](https://github.com/jasperapp/jasper/pull/198) Thanks [@Monchi](https://github.com/Monchi)
-  - [#199](https://github.com/jasperapp/jasper/pull/199)
+  - Mark updates by myself as read by default [#198](https://github.com/jasperapp/jasper/pull/198) Thanks [@Monchi](https://github.com/Monchi)
+  - Workaround involves value on no participants issues [#199](https://github.com/jasperapp/jasper/pull/199)
+  - Unexpectation moving stream when select a issue [#200](https://github.com/jasperapp/jasper/pull/200)
 
 # 1.0.2 (2020/10/07)
 - **Fix**


### PR DESCRIPTION
ブラウザ内でissueのリンクをクリックしたときに、Jasper側でもそのissueを選択するようにしていた。
このとき、そのissueが紐づくstreamに強制的に移動していた。
この移動が予期しないstreamの移動の原因の可能性が高い。

そこで、そのissueが現在選択しているstreamに紐づく場合は、streamを移動しないようにした。