### PR TITLE
Fixed access token validation during setup

### DIFF
--- a/src/Renderer/Repository/UserPrefRepo.ts
+++ b/src/Renderer/Repository/UserPrefRepo.ts
@@ -160,7 +160,7 @@ class _UserPref {
     if (github.host === 'api.github.com' && github.pathPrefix) return false;
 
     if (!github.accessToken) return false;
-    if (!github.accessToken.match(/^[0-9a-z]+$/)) return false;
+    if (!github.accessToken.match(/^[0-9a-zA-Z_]+$/)) return false;
 
     if (!github.webHost) return false;
     if (github.host === 'api.github.com' && github.webHost !== 'github.com') return false;


### PR DESCRIPTION
Validation failed because the characters in the access token contained uppercase letters and underlines.