### PR TITLE
fix(UserPrefRepo): update personal access token format

### DIFF
--- a/src/Renderer/Repository/UserPrefRepo.ts
+++ b/src/Renderer/Repository/UserPrefRepo.ts
@@ -160,7 +160,7 @@ class _UserPref {
     if (github.host === 'api.github.com' && github.pathPrefix) return false;
 
     if (!github.accessToken) return false;
-    if (!github.accessToken.match(/^[0-9a-z]+$/)) return false;
+    if (!github.accessToken.match(/^(?:[a-f0-9]{40}|ghp_\w{36,251})$/)) return false;
 
     if (!github.webHost) return false;
     if (github.host === 'api.github.com' && github.webHost !== 'github.com') return false;


### PR DESCRIPTION
# Summary

GitHub changed the format of personal access token and this makes token validation failure.
https://github.blog/2021-04-05-behind-githubs-new-authentication-token-formats/

This PR is for supporting the new GitHub access token format (e.g., `ghp_....`)

Ref:
- https://github.com/Homebrew/brew/pull/10847
- https://github.com/sindresorhus/notifier-for-github/pull/246

# Test

Tested the new regex with my revoked tokens

```node
➜  jasper git:(fix-new-access-token-format) node
Welcome to Node.js v12.14.0.
Type ".help" for more information.
> 'db03ece8f912d2f5215ce24934003cc627b73019'.match(/^(?:[a-f0-9]{40}|ghp_\w{36,251})$/)
[
  'db03ece8f912d2f5215ce24934003cc627b73019',
  index: 0,
  input: 'db03ece8f912d2f5215ce24934003cc627b73019',
  groups: undefined
]
> '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'.match(/^(?:[a-f0-9]{40}|ghp_\w{36,251})$/)
[
  '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',
  index: 0,
  input: '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',
  groups: undefined
]
```

Confirmed it's working locally as well (`npm run mac:run`)
