### PR TITLE
Avoid to access null when the issue author is a ghost

### DIFF
--- a/src/Renderer/Library/GitHub/V4/GitHubV4IssueClient.ts
+++ b/src/Renderer/Library/GitHub/V4/GitHubV4IssueClient.ts
@@ -47,11 +47,15 @@ export class GitHubV4IssueClient extends GitHubV4Client {
 
     // workaround: participantsが空の場合が何故か発生するので、authorを明示的にinvolvesに入れる
     // orgのvisibleじゃないユーザがauthorの場合はparticipantsに表示されないぽい？
-    involves.push({
-      login: v4Issue.author.login,
-      name: v4Issue.author.login,
-      avatar_url: v4Issue.author.avatarUrl,
-    });
+    //
+    // author is null when the author is a deleted user.
+    if (v4Issue.author) {
+      involves.push({
+        login: v4Issue.author.login,
+        name: v4Issue.author.login,
+        avatar_url: v4Issue.author.avatarUrl,
+      });
+    }
 
     // workaround: participantsが空の場合が何故か発生するので、assigneesを明示的にinvolvesに入れる
     // orgのvisibleじゃないユーザがassigneeの場合はparticipantsに表示されないぽい？

--- a/src/Renderer/Library/Type/RemoteGitHubV4/RemoteGitHubV4IssueNodesEntity.ts
+++ b/src/Renderer/Library/Type/RemoteGitHubV4/RemoteGitHubV4IssueNodesEntity.ts
@@ -9,7 +9,7 @@ export type RemoteGitHubV4IssueEntity = {
   node_id: string;
   bodyHTML: string;
   updatedAt: string;
-  author: {
+  author?: {
     login: string;
     avatarUrl: string;
   };


### PR DESCRIPTION
When Jasper fetches an issue which the author is a ghost (deleted user),
Jasper prints a TypeError on GitHubV4IssueClient.ts:51 in the dev console for the main process.

```
TypeError: Cannot read property 'login' of null
```

Because GitHub API returns `null` as the author when the user is
deleted.

This patch fixes this problem with adding a null-guard.


# Note

I've found this problem on this issue `https://github.com/ujihisa/neco-look/issues/20` (as code to avoid backlink).




Jasper may still have similar issues in other places but I haven't checked them. This patch also updates the type definition, but it doesn't affect the type checking because `strictNullChecks: false` is configured in tsconfig.