### PR TITLE
Relax maxPage to fetch watching repos

### DIFF
--- a/src/Renderer/Library/GitHub/GitHubUserClient.ts
+++ b/src/Renderer/Library/GitHub/GitHubUserClient.ts
@@ -38,7 +38,7 @@ export class GitHubUserClient extends GitHubClient {
   }
 
   // https://docs.github.com/en/free-pro-team@latest/rest/reference/activity#list-repositories-watched-by-the-authenticated-user
-  async getUserWatchings(page: number = 1, maxPage: number = 10): Promise<{error?: Error; watchings?: RemoteUserWatchingEntity[]}> {
+  async getUserWatchings(page: number = 1, maxPage: number = 30): Promise<{error?: Error; watchings?: RemoteUserWatchingEntity[]}> {
     const {error, headers, body} = await this.request<RemoteUserWatchingEntity[]>('/user/subscriptions', {per_page: 100, page});
     if (error) return {error};
 


### PR DESCRIPTION
This PR increases maxPage threshold to fetch watching repositories from 10 to 30.

The current threshold is too small for me because I have 1,000+ watching repos which need 10+ pages.

I'm not sure which number is appropriate for the threshold, but I guess `30` is enough in most cases.


By the way, this change is related to #220 a bit. This PR will increase query executions but #220 will reduce the impact of the increased query execution.
