### PR TITLE
chore(CI): Add build linux app job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,22 @@
+name: build
+on: push
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: "12"
+        cache: 'npm'
+    - run: npm ci
+
+    - run: npm run env:setup
+    - run: npm run linux:build
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: linux-app
+        path: |
+          out/linux/Jasper


### PR DESCRIPTION
Add simple CI job just only build Linux app and upload zip to Github Actions artifact.


Thank you for creating awesome app! I'm using Jasper everyday both my work and private.

On the other hand, I'm worried about the maintainability of Jasper's development.
DEVELOP.md says that it only supports v10 and v12 of nodejs, but today's LTS version is v16 and v12 is already in maintenance mode. Also, the version of Electron is quite old.

I want to continue using Jasper for a long time, and I hope you will continue to develop it with people like me who want to contribute to Jasper.
I thought about what I could do to get you to continue developing, and Jasper didn't have CI yet, so I created a job that simply builds a Linux app. It helps us when upgrading nodejs or Electron or some of dependencies.