### PR TITLE
自分の更新かどうかをチェックするためにレビューコメントを使う

### DIFF
--- a/src/Renderer/Library/Type/RemoteGitHubV4/RemoteGitHubV4IssueNodesEntity.ts
+++ b/src/Renderer/Library/Type/RemoteGitHubV4/RemoteGitHubV4IssueNodesEntity.ts
@@ -42,12 +42,29 @@ export type RemoteGitHubV4IssueEntity = {
   mergedAt?: string;
   mergeable?: 'CONFLICTING' | 'MERGEABLE' | 'UNKNOWN';
   reviewRequests?: {
-    nodes: {requestedReviewer: RemoteGithubV4UserEntity}[];
+    nodes: { requestedReviewer: RemoteGithubV4UserEntity }[];
   };
   reviews?: {
     nodes: RemoteGitHubV4Review[];
+  };
+  reviewThreads?: {
+    nodes: RemoteGitHubV4ReviewThread[];
   }
 }
+
+export type RemoteGitHubV4ReviewThread = {
+  comments: {
+    nodes: RemoteGitHubV4ReviewThreadComment[]
+  };
+};
+
+export type RemoteGitHubV4ReviewThreadComment = {
+  author: {
+    login: string;
+    avatarUrl: string;
+  };
+  updatedAt: string;
+};
 
 export type RemoteGithubV4UserEntity = {
   login: string;


### PR DESCRIPTION
- 自分が更新したPRの通知は受け取らないようにしたい
- そのために「PRの最終更新者が自分の場合は通知をしない」というようにしていた
- しかし、タイムラインだけではそのPRの最終更新者を取得できていなかった
- 最終更新者を知るためにはレビューコメントもすべてチェックする必要があった