### PR TITLE
fix issue row style with long repo name

### DIFF
--- a/src/Renderer/Library/View/IssueRow.tsx
+++ b/src/Renderer/Library/View/IssueRow.tsx
@@ -1277,6 +1277,8 @@ const Footer = styled(View)`
 const RepoName = styled(View)`
   flex-direction: row;
   align-items: center;
+  flex-wrap: wrap;
+  padding-right: ${space.small}px;
 `;
 
 const RepoNameText = styled(Text)`
@@ -1340,7 +1342,7 @@ const CommentCountText = styled(Text)`
 `;
 
 const UpdatedAt = styled(View)`
-  padding-left: ${space.small}px;
+  flex-shrink: 0;
 `;
 
 const UpdatedAtText = styled(Text)`


### PR DESCRIPTION
The style of repository name and updatedAt label on issue row is weird when the repository name is long.

Before:

https://user-images.githubusercontent.com/16265411/170862143-b396aa0c-86ec-464a-b36e-6dad8c7f4a5c.mov

After:

https://user-images.githubusercontent.com/16265411/170862159-a1de838c-00f3-4903-a262-ddf62f2ae27f.mov


