### PR TITLE
Fix highlight style when Github appearance setting is 'system with sync'

### DIFF
--- a/src/Renderer/Fragment/Browser/BrowserFragmentAsset/style.css
+++ b/src/Renderer/Fragment/Browser/BrowserFragmentAsset/style.css
@@ -46,7 +46,9 @@
 }
 
 :root[data-color-mode=light][data-light-theme*=dark],
-:root[data-color-mode=dark][data-dark-theme*=dark] {
+:root[data-color-mode=dark][data-dark-theme*=dark],
+:root[data-color-mode=auto][data-light-theme*=dark],
+:root[data-color-mode=auto][data-dark-theme*=dark] {
   --highlight-color: #4f4d32;
   --highlight-indicator-bg: #666666;
   --highlight-indicator-mark-bg: #238c3c;


### PR DESCRIPTION
# Problem 

#273 solves this problem only when Github appearance settings is 'Single theme'
This Problem is still occurring in 'Sync with sytem'

![image](https://user-images.githubusercontent.com/16717502/211142760-747628b3-77a5-4bcf-9c3d-90777c97630a.png)

# Solution

Add CSS selector `data-color-mode=auto`

![image](https://user-images.githubusercontent.com/16717502/211143046-b60e04e3-0ac1-4166-902d-990d37db3b0b.png)
